### PR TITLE
takazawa コンフリクト解消の際の記述ミス修正

### DIFF
--- a/app/controllers/exhibitions_controller.rb
+++ b/app/controllers/exhibitions_controller.rb
@@ -24,7 +24,7 @@ class ExhibitionsController < ApplicationController
   end
 
   def show
-   
+  
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,6 @@ Rails.application.routes.draw do
 
   }
   root to: "exhibitions#index"
-  resources :exhibitions ,only: [:show]
 
  
   resources :mypage ,only: :index
@@ -15,7 +14,7 @@ Rails.application.routes.draw do
   resources :addresses ,only: :index
   resources :editmails ,only: :index
   
-  resources :exhibitions,only: [:index, :new, :create] do
+  resources :exhibitions,only: [:index, :new, :create, :show] do
     collection do
       get 'modal'
     end


### PR DESCRIPTION
# What 
ルートの記述でコンフリクトを解消した際にresources :exhibitionsが二重に記述されていたのでひとつまとめた

# Why
エラーが出てしまうため