### PR TITLE
画像差し替え-add

### DIFF
--- a/app/views/exhibitions/show.html.haml
+++ b/app/views/exhibitions/show.html.haml
@@ -34,7 +34,7 @@
         .show-box__foot 
           %ul
             %li 
-            - objects = @exhibition.images.order("created_at DESC")
+            - objects = @exhibition.images
             - objects.each do |object|
               %li.main__show__content__top__itemInfo__image__ul__li
                 = image_tag object.image.url


### PR DESCRIPTION
# What
詳細ページの画像が編集で画像を追加する度に追加された画像が一番前に来てしまう。
不具合の解消。

# Why
最終課題を終わらせる為。